### PR TITLE
fix#1 ContentLinkのプラグイン名がBaserCoreのままになる問題を解決

### DIFF
--- a/src/Controller/Component/BcDbMigrator5Component.php
+++ b/src/Controller/Component/BcDbMigrator5Component.php
@@ -254,7 +254,13 @@ class BcDbMigrator5Component extends BcDbMigratorComponent implements BcDbMigrat
 		foreach($records as $record) {
 			$record['site_id'] = $this->getSiteId($record['site_id']);
 			unset($record['deleted']);
-			if($record['plugin'] === 'Core') $record['plugin'] = 'BaserCore';
+			if($record['plugin'] === 'Core') {
+				if($record['type'] === 'ContentLink') {
+						$record['plugin'] = 'BcContentLink';
+				} else {
+						$record['plugin'] = 'BaserCore';
+				}
+			}
 			if($record['plugin'] === 'Blog') $record['plugin'] = 'BcBlog';
 			if($record['plugin'] === 'Mail') $record['plugin'] = 'BcMail';
 			if($record['plugin'] === 'Uploader') $record['plugin'] = 'BcUploader';


### PR DESCRIPTION
@ryuring 

こちらContentLinkのプラグイン名をBcContentLinkにすることで、復元時のURLの末尾にスラッシュがついてしまうバグも併せて解決可能です。
お手数ですが、ご確認の上マージをお願いします。