### PR TITLE
Dev #13

### DIFF
--- a/config/setting.php
+++ b/config/setting.php
@@ -1,0 +1,10 @@
+<?php
+return [
+    'BcDbMigrator' => [
+        // 追加indexが貼られているパターン
+        'sqlRelationNames' => [
+            'blog_post_id',
+            'blog_content_id',
+        ],
+    ]
+];


### PR DESCRIPTION
@ryuring 

取り急ぎ、setting.phpにてカラムを設定し、

```
<?php
return [
    'BcDbMigrator' => [
        // 追加indexが貼られているパターン
        'sqlRelationNames' => [
            'blog_post_id',
            'blog_content_id',
        ],
    ]
];
```
`'unique' => 1`
と
`'unique' => 0`
の２つのパターンに対応しています。

新環境でプラグインテーブルがインストール済み且つ無効状態であれば、正常に動作するところまで確認しています。
baserCMS version5.1.3

お手数ですが、ご確認の上、マージをお願いできますでしょうか？
